### PR TITLE
merge dev_supabase

### DIFF
--- a/supabase/migrations/20250307081741_mid_term.sql
+++ b/supabase/migrations/20250307081741_mid_term.sql
@@ -167,7 +167,7 @@ alter table "public"."profilesCategory" validate constraint "profilesCategory_pr
 
 set check_function_bodies = off;
 
-CREATE OR REPLACE FUNCTION public."accept-co-authoring"(post_id integer)
+CREATE OR REPLACE FUNCTION public."accept_co_authoring"(post_id integer)
  RETURNS boolean
  LANGUAGE plpgsql
 AS $function$BEGIN
@@ -653,6 +653,50 @@ for select
 to public
 using (true);
 
+
+CREATE TRIGGER enforce_user_is_author_of_post_to_pin BEFORE UPDATE ON public.profiles FOR EACH ROW EXECUTE FUNCTION user_is_author_of_post_to_pin();
+
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.remove_authorless_posts()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$BEGIN
+  IF NOT EXISTS (SELECT 1 FROM authored WHERE id = OLD.id) THEN
+    DELETE FROM posts WHERE id = OLD.id;
+  END IF;
+  RETURN OLD;
+END;$function$
+;
+
+create policy "allow posting"
+on "public"."posts"
+as permissive
+for insert
+to authenticated
+with check (true);
+
+
+CREATE TRIGGER enforce_remove_authorless_posts AFTER DELETE ON public.authored FOR EACH ROW EXECUTE FUNCTION remove_authorless_posts();
+
+
+
+drop trigger if exists "enforce_user_is_author_of_post_to_pin" on "public"."profiles";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.make_poster_first_author()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$BEGIN
+  insert into authored (profile, post) values (auth.uid(), NEW.id);
+END;$function$
+;
+
+CREATE TRIGGER enforce_make_user_first_author AFTER INSERT ON public.posts FOR EACH ROW EXECUTE FUNCTION make_poster_first_author();
 
 CREATE TRIGGER enforce_user_is_author_of_post_to_pin BEFORE INSERT OR UPDATE ON public.profiles FOR EACH ROW EXECUTE FUNCTION user_is_author_of_post_to_pin();
 

--- a/supabase/migrations/20250307081741_mid_term.sql
+++ b/supabase/migrations/20250307081741_mid_term.sql
@@ -682,9 +682,6 @@ with check (true);
 CREATE TRIGGER enforce_remove_authorless_posts AFTER DELETE ON public.authored FOR EACH ROW EXECUTE FUNCTION remove_authorless_posts();
 
 
-
-drop trigger if exists "enforce_user_is_author_of_post_to_pin" on "public"."profiles";
-
 set check_function_bodies = off;
 
 CREATE OR REPLACE FUNCTION public.make_poster_first_author()
@@ -697,8 +694,4 @@ END;$function$
 ;
 
 CREATE TRIGGER enforce_make_user_first_author AFTER INSERT ON public.posts FOR EACH ROW EXECUTE FUNCTION make_poster_first_author();
-
-CREATE TRIGGER enforce_user_is_author_of_post_to_pin BEFORE INSERT OR UPDATE ON public.profiles FOR EACH ROW EXECUTE FUNCTION user_is_author_of_post_to_pin();
-
-
 


### PR DESCRIPTION
updated the calling conditions of verification of ownership for pin, which was causing an error, preventing registration
added a policy to actually post and a trigger to make the user it’s other
added automatic removal of authorless posts